### PR TITLE
stack test --coverage not working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cabal.sandbox.config
 .stack-work/
 cabal.project.local
 .HTF/
+*.tix

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,10 @@ before_install:
     - export PATH=$HOME/.local/bin:$PATH
     - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
     - stack setup
+    - stack clean
 
 install:
-    - stack build
+    - stack build --coverage
 
 script:
     - stack --no-terminal --skip-ghc-check test --haddock --no-haddock-deps

--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ Run the test suite:
 
 Code coverage is enabled by passing the `--coverage` flag:
 
-`stack test --coverage`
+`stack test --coverage --ghc-options "--fforce-recomp"` (see https://github.com/commercialhaskell/stack/issues/1305 for more information about use of `--ghc-options` option to force recompilation)
+
+Alternatively, force recompilation using the `stack clean` command:
+
+`stack clean && stack build --coverage && stack test --coverage`
 
 Generate Haskell programming coverage (https://wiki.haskell.org/Haskell_program_coverage) report:
 


### PR DESCRIPTION
### Description

Invoking the command `stack test --coverage` generates a coverage report.

### Issues Resolved

Closes #2 

### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
